### PR TITLE
Prevent camera clipping through walls

### DIFF
--- a/addons/proto_controller/proto_controller.tscn
+++ b/addons/proto_controller/proto_controller.tscn
@@ -28,5 +28,8 @@ shape = SubResource("CapsuleShape3D_iof21")
 [node name="Head" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0)
 
-[node name="Camera3D" type="Camera3D" parent="Head"]
+[node name="SpringArm3D" type="SpringArm3D" parent="Head"]
+spring_length = 3.0
+
+[node name="Camera3D" type="Camera3D" parent="Head/SpringArm3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)


### PR DESCRIPTION
https://github.com/Lightgarden-713/Pavojam/issues/5

Added spring arm setup by following godot documentation: https://docs.godotengine.org/en/latest/tutorials/3d/spring_arm.html

Code was already there so no changes needed on that side. I  adjusted the spring arm length to match the current distance from the camera towards the pivot.

Before:

[Screencast from 12-22-2025 09:52:56 PM.webm](https://github.com/user-attachments/assets/45537892-81ff-46a6-8fb8-f928f8996b62)

After:

[Screencast from 12-22-2025 09:49:58 PM.webm](https://github.com/user-attachments/assets/11d6a0dd-879a-46b0-9a8e-ca98f4408b36)