### PR TITLE
reverse order of hitbox - hurtbox interaction

### DIFF
--- a/scene_components/hitbox_component.tscn
+++ b/scene_components/hitbox_component.tscn
@@ -3,7 +3,10 @@
 [ext_resource type="Script" uid="uid://c0wcipcd8wd0f" path="res://scripts/hitbox_component.gd" id="1_uks3l"]
 
 [node name="HitboxComponent" type="Area3D"]
-monitoring = false
+monitorable = false
 script = ExtResource("1_uks3l")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+
+[connection signal="area_entered" from="." to="." method="_on_area_entered"]
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scene_components/hurtbox_component.tscn
+++ b/scene_components/hurtbox_component.tscn
@@ -3,9 +3,7 @@
 [ext_resource type="Script" uid="uid://dqbf5kjjc7fxx" path="res://scripts/hurtbox_component.gd" id="1_mlgxs"]
 
 [node name="HurtboxComponent" type="Area3D"]
-monitorable = false
+monitoring = false
 script = ExtResource("1_mlgxs")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-
-[connection signal="area_entered" from="." to="." method="_on_area_entered"]

--- a/scripts/hitbox_component.gd
+++ b/scripts/hitbox_component.gd
@@ -6,5 +6,12 @@ signal on_hit(target: HurtboxComponent)
 @export_category("stats")
 @export var damage_amount: float
 
-func register_hit(hurtbox: HurtboxComponent) -> void:
+func _on_area_entered(hurtbox: HurtboxComponent) -> void:
+	if hurtbox == null: return
+
+	hurtbox.get_hit(self)
 	on_hit.emit(hurtbox)
+
+func _on_body_entered(_body: Node3D) -> void:
+	# Currently the only collidable body should be the level itself
+	on_hit.emit(null)

--- a/scripts/hurtbox_component.gd
+++ b/scripts/hurtbox_component.gd
@@ -13,9 +13,5 @@ func _ready() -> void:
 	if owner_health_component == null:
 		push_error("Health component not set for hitbox")
 
-
-func _on_area_entered(hitbox: HitboxComponent) -> void:
-	if hitbox == null: return
-
+func get_hit(hitbox: HitboxComponent) -> void:
 	owner_health_component.take_damage(hitbox.damage_amount)
-	hitbox.register_hit(self)


### PR DESCRIPTION
- made hitbox monitoring
- made hurtbox monitorable
- updated signals and corresponding callbacks

These changes makes the projectile disappear when colliding with the colliseum walls