### PR TITLE
Center UI on level up and handle visibility

### DIFF
--- a/scenes/level.tscn
+++ b/scenes/level.tscn
@@ -45,61 +45,66 @@ font_size = 48
 
 [sub_resource type="Animation" id="Animation_8iemx"]
 length = 0.001
+step = 0.25
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
+tracks/0/path = NodePath(".:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector2(256, -500)]
+"values": [Color(1, 1, 1, 0)]
 }
 
 [sub_resource type="Animation" id="Animation_t1rx8"]
 resource_name = "exit"
-tracks/0/type = "value"
+length = 0.5
+step = 0.25
+tracks/0/type = "method"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 2
+tracks/0/path = NodePath(".")
+tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector2(256, 64), Vector2(256, -500)]
-}
-tracks/1/type = "method"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath(".")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(1),
+"times": PackedFloat32Array(0.5),
 "transitions": PackedFloat32Array(1),
 "values": [{
 "args": [],
 "method": &"_on_exit_animation_finished"
 }]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
 
 [sub_resource type="Animation" id="Animation_olg7q"]
 resource_name = "fade_in"
+length = 0.5
+step = 0.25
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 2
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
+"times": PackedFloat32Array(0, 0.5),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector2(256, -500), Vector2(256, 64)]
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_64w2a"]
@@ -136,6 +141,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.8238201, 0.14361048, 1.938
 
 [node name="GenericEnemy" parent="World" instance=ExtResource("2_w7c3h")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.527357, 0.6495738, 1.9063959)
+collision_mask = 6
 speed = 1.0
 
 [node name="ExperienceOrb" parent="World" instance=ExtResource("4_ppgk2")]
@@ -224,6 +230,7 @@ layout_mode = 2
 text = "Next Wave"
 
 [node name="LevelUpUI" type="PanelContainer" parent="UI" node_paths=PackedStringArray("game_manager", "animation_player", "upgrade_options_container")]
+modulate = Color(1, 1, 1, 0)
 custom_minimum_size = Vector2(640, 480)
 anchors_preset = 8
 anchor_left = 0.5
@@ -231,9 +238,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -320.0
-offset_top = -824.0
+offset_top = -240.0
 offset_right = 320.0
-offset_bottom = -343.99988
+offset_bottom = 240.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4

--- a/scripts/experience_orb.gd
+++ b/scripts/experience_orb.gd
@@ -64,14 +64,11 @@ func chase(delta):
 		collect()
 
 func _on_pickup_range_body_entered(player: ProtoController) -> void:
-	print("body entered")
-
 	if player != null:
 		magnetize(player)
 
 # Only body colliding with xp ball is the level geometry
 func _on_body_entered(_body: Node) -> void:
-	print("Touched Ground")
 	state = State.IDLE
 	# enable magnet
 	pickup_range.monitoring = true

--- a/scripts/ui/level_up_ui.gd
+++ b/scripts/ui/level_up_ui.gd
@@ -12,7 +12,11 @@ var selected_upgrade : PlayerUpgrade = null
 
 signal exited
 
+func _ready() -> void:
+	visible = false
+
 func open(upgrades_to_choose: Array[PlayerUpgrade]) -> void:
+	visible = true
 	# Instantiate options
 	for upgrade in upgrades_to_choose:
 		# create UI node
@@ -31,6 +35,7 @@ func _on_upgrade_selected(upgrade: PlayerUpgrade) -> void:
 	self.selected_upgrade = upgrade
 
 func _on_exit_animation_finished() -> void:
+	visible = false
 	print("exit animation finished")
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 


### PR DESCRIPTION
The LevelUpUI already had a center anchor but doing an animation with position changes, overided that configuration.

Also that anchor was not working properly until I clicked the anchor button on the top bar: 
<img width="3796" height="1869" alt="image" src="https://github.com/user-attachments/assets/1114af8d-57cc-4896-8dfd-f2f49e8c6fd8" />

That did the trick, now the UI is always in the center of the screen no matter the resolution. The rest is handling the visibility true/false when leveling up and a basic animation using the modulate variable, but this is optional.

I checked how Megabonk does it and its a visibile false to true instantaneously, but it handles a scaling animation with sunshine effected that scales with the panels: (You can see the UI VERY tiny on the sides)

<img width="986" height="557" alt="image" src="https://github.com/user-attachments/assets/94c3d641-786e-4c36-a9d2-12dfc2835cfd" />

<img width="986" height="546" alt="image" src="https://github.com/user-attachments/assets/ee650cef-b736-40b3-81bf-e13d7aa81391" />

<img width="976" height="560" alt="image" src="https://github.com/user-attachments/assets/6e5afb8a-548a-4e67-8524-ba730d81dc1c" />

49:22 of the video https://www.youtube.com/watch?v=KB5Z5g5Nk8c&t=2963s Use `,` and `.` to move frame by frame. Everything happens in 1 second or less