### PR TITLE
Fix format command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
-	find . -type f -name "*.gd" | xargs gdscript-formatter lint
+	find . -type f -name "*.gd" | xargs -I {} gdscript-formatter {} lint
 
 format-check:
 	find . -type f -name "*.gd" | xargs gdscript-formatter --check


### PR DESCRIPTION
The format command was sometimes failing (and not formatting files). This was due to a mistake I made with the order of the command arguments. From the formatter help:

```bash
Usage: gdscript-formatter [OPTIONS] [FILES]... [COMMAND]
```

Since  `lint` is a command it needs to go at the end of the invocation