### PR TITLE
Expand projectile attack

### DIFF
--- a/addons/proto_controller/proto_controller.tscn
+++ b/addons/proto_controller/proto_controller.tscn
@@ -72,9 +72,11 @@ shape = SubResource("CapsuleShape3D_0rk7u")
 
 [node name="ProjectileAttack" parent="." instance=ExtResource("6_h60nn")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.0921607, -0.41275918)
-attack_mode = 1
+aim_mode = 1
+shoot_mode = 1
 projectiles_per_attack = 1
 time_between_projectiles = 0.1
+angle_between_projectiles = 10.0
 projectile_collision_mask = 2
 
 [node name="EntityTracker" parent="ProjectileAttack" index="0"]

--- a/addons/proto_controller/proto_controller.tscn
+++ b/addons/proto_controller/proto_controller.tscn
@@ -73,7 +73,6 @@ shape = SubResource("CapsuleShape3D_0rk7u")
 [node name="ProjectileAttack" parent="." instance=ExtResource("6_h60nn")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.0921607, -0.41275918)
 aim_mode = 1
-shoot_mode = 1
 projectiles_per_attack = 1
 time_between_projectiles = 0.1
 angle_between_projectiles = 10.0

--- a/addons/proto_controller/proto_controller.tscn
+++ b/addons/proto_controller/proto_controller.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bs72ogkvdd7d6"]
+[gd_scene load_steps=12 format=3 uid="uid://bs72ogkvdd7d6"]
 
 [ext_resource type="Script" uid="uid://bb7xj3gm15bgx" path="res://addons/proto_controller/proto_controller.gd" id="1_ucva2"]
 [ext_resource type="PackedScene" uid="uid://c1i3f13st5yow" path="res://scene_components/health_component.tscn" id="2_5hfox"]
@@ -74,6 +74,7 @@ shape = SubResource("CapsuleShape3D_0rk7u")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.0921607, -0.41275918)
 attack_mode = 1
 projectiles_per_attack = 1
+time_between_projectiles = 0.1
 projectile_collision_mask = 2
 
 [node name="EntityTracker" parent="ProjectileAttack" index="0"]

--- a/scripts/projectile_attack.gd
+++ b/scripts/projectile_attack.gd
@@ -72,6 +72,15 @@ func shoot() -> void:
 	entities_in_range.append_array(entity_tracker.entities_within_detection_range)
 
 	if aim_mode == AimMode.AUTO_AIMED and len(entities_in_range) == 0:
+		# Consume shot
+		if shoot_mode == ShootMode.SEQUENTIAL:
+			remaining_projectiles_for_current_attack -= 1
+			time_until_next_projectile = time_between_projectiles
+			if remaining_projectiles_for_current_attack == 0:
+				end_attack()
+		elif shoot_mode == ShootMode.PARALLEL:
+			end_attack()
+
 		return
 
 	# Calculate direction towards target

--- a/scripts/projectile_attack.gd
+++ b/scripts/projectile_attack.gd
@@ -19,7 +19,6 @@ enum ShootMode { SEQUENTIAL, PARALLEL }
 
 @export_subgroup("Sequential Shooting Stats")
 @export var time_between_projectiles: float
-@export var can_retarget: bool
 
 @export_subgroup("Parallel Shooting Stats")
 @export var angle_between_projectiles: float
@@ -101,7 +100,6 @@ func shoot() -> void:
 
 
 ## Assume we always have at least one entity in range for autoaimed attacks, otherwise we don't even call this.
-## Might modify the provided entities in range
 func get_aim_direction(entities_in_range: Array[Node3D]) -> Vector3:
 	if aim_mode == AimMode.AIMED:
 		# Forward direction
@@ -115,10 +113,6 @@ func get_aim_direction(entities_in_range: Array[Node3D]) -> Vector3:
 		for entity in entities_in_range:
 			if global_position.distance_to(entity.global_position) < global_position.distance_to(closest_entity.global_position):
 				closest_entity = entity
-
-		# Can only target once per shooting
-		if not can_retarget:
-			entities_in_range.erase(closest_entity)
 
 		return global_position.direction_to(closest_entity.global_position)
 


### PR DESCRIPTION
Tweaked attacks to make a bit more sense. Now we have 2 kinds of modes for configuring how the attack works:

- Aim mode: when choosing an attack direction, this determines whether it aims at the direction the player is looking at (either with the camera or with the character)
- Shoot mode: you choose whether all projectiles are shot at once (with a fan-like organization of projectiles) or sequentially.

I thought of splitting each combination of aim mode and shoot mode (because of the edge cases). I think for now it works having it as part of a single script despite having to handle some edge cases. If we were to split it we'd have to maintain 4 different scripts. Overall if we think we might want very complex attack patterns, splitting it might be the best approach. But considering the current context I don't think it would make sense to spend time on it instead of other priorities